### PR TITLE
refactor: replace lazy_static with std::sync::LazyLock and bump version to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,6 @@ dependencies = [
  "actix-rt",
  "env_logger",
  "hyper 0.14.32",
- "lazy_static",
  "log",
  "openssl",
  "prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "tado-exporter"
-version = "2.0.11"
+version = "2.1.0"
 dependencies = [
  "actix-rt",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 [dependencies]
 hyper = { version = "0.14", features = ["server", "runtime", "http1", "http2"] }
 tokio = { version = "1", features = ["full"] }
-lazy_static = "1.5"
 prometheus = "0.14"
 reqwest = { version = "0.13", features = ["json", "form"] }
 serde = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tado-exporter"
-version = "2.0.11"
+version = "2.1.0"
 authors = ["Vincent Composieux <vincent@composieux.fr>"]
 edition = "2024"
 

--- a/src/tado/client.rs
+++ b/src/tado/client.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 use std::vec::Vec;
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use log::{error, info};
 use reqwest;
 
@@ -13,12 +13,13 @@ use super::model::{
 
 const AUTH_PENDING_MESSAGE: &str = "authorization_pending";
 
-lazy_static! {
-    // TODO: POST DEVICE - https://login.tado.com/oauth2/device
-    static ref AUTH_START_URL: reqwest::Url = "https://login.tado.com/oauth2/device_authorize".parse().unwrap();
-    static ref AUTH_TOKEN_URL: reqwest::Url = "https://login.tado.com/oauth2/token".parse().unwrap();
-    pub static ref BASE_URL: reqwest::Url = "https://my.tado.com/api/v2/".parse().unwrap();
-}
+static AUTH_START_URL: LazyLock<reqwest::Url> =
+    LazyLock::new(|| "https://login.tado.com/oauth2/device_authorize".parse().unwrap());
+static AUTH_TOKEN_URL: LazyLock<reqwest::Url> =
+    LazyLock::new(|| "https://login.tado.com/oauth2/token".parse().unwrap());
+pub static BASE_URL: LazyLock<reqwest::Url> =
+    LazyLock::new(|| "https://my.tado.com/api/v2/".parse().unwrap());
+
 
 #[allow(dead_code)]
 pub struct Client {

--- a/src/tado/metrics.rs
+++ b/src/tado/metrics.rs
@@ -3,60 +3,81 @@ use std::convert::Infallible;
 use super::model::{WeatherApiResponse, ZoneStateResponse};
 
 use hyper::{Body, Request, Response, header::CONTENT_TYPE};
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use log::info;
 use prometheus::{Encoder, GaugeVec, TextEncoder};
 
-lazy_static! {
-    pub static ref ACTIVITY_HEATING_POWER: GaugeVec = register_gauge_vec!(
+pub static ACTIVITY_HEATING_POWER: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_activity_heating_power_percentage",
         "The % of heating power in a specific zone.",
         &["zone", "type"]
     )
-    .unwrap();
-    pub static ref ACTIVITY_AC_POWER: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static ACTIVITY_AC_POWER: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_activity_ac_power_value",
         "The value of ac power in a specific zone.",
         &["zone", "type"]
     )
-    .unwrap();
-    pub static ref SETTING_TEMPERATURE: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static SETTING_TEMPERATURE: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_setting_temperature_value",
         "The temperature of a specific zone in celsius degres.",
         &["zone", "type", "unit"]
     )
-    .unwrap();
-    pub static ref SENSOR_TEMPERATURE: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static SENSOR_TEMPERATURE: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_sensor_temperature_value",
         "The temperature of a specific zone in celsius degres.",
         &["zone", "type", "unit"]
     )
-    .unwrap();
-    pub static ref SENSOR_HUMIDITY_PERCENTAGE: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static SENSOR_HUMIDITY_PERCENTAGE: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_sensor_humidity_percentage",
         "The % of humidity in a specific zone.",
         &["zone", "type"]
     )
-    .unwrap();
-    pub static ref WEATHER_SOLAR_INTENSITY: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static WEATHER_SOLAR_INTENSITY: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "weather_solar_intensity",
         "Solar intensity outside the house.",
         &[]
     )
-    .unwrap();
-    pub static ref WEATHER_OUTSIDE_TEMPERATURE: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static WEATHER_OUTSIDE_TEMPERATURE: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "weather_outside_temperature",
         "Temperature outside the house.",
         &["unit"]
     )
-    .unwrap();
-    pub static ref SENSOR_WINDOW_OPENED: GaugeVec = register_gauge_vec!(
+    .unwrap()
+});
+
+pub static SENSOR_WINDOW_OPENED: LazyLock<GaugeVec> = LazyLock::new(|| {
+    register_gauge_vec!(
         "tado_sensor_window_opened",
         "1 if the sensor detected a window is open, 0 otherwise.",
         &["zone", "type"]
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 pub fn set_zones(zones: Vec<ZoneStateResponse>) {
     for zone in zones {


### PR DESCRIPTION
Replaced external lazy_static crate dependency with native std::sync::LazyLock

Removed lazy_static from Cargo.toml

Bumped package version to 2.1.0